### PR TITLE
drop versionsuffix + set default_cuda_version + clarify comments w.r.t. using custom CUDA as dependency in NVHPC easyconfig

### DIFF
--- a/easybuild/easyconfigs/n/NVHPC/NVHPC-20.7.eb
+++ b/easybuild/easyconfigs/n/NVHPC/NVHPC-20.7.eb
@@ -1,7 +1,5 @@
 name = 'NVHPC'
 version = '20.7'
-local_gccver = '9.3.0'
-versionsuffix = '-GCC-%s' % local_gccver
 
 homepage = 'https://developer.nvidia.com/hpc-sdk/'
 description = """C, C++ and Fortran compilers included with the NVIDIA HPC SDK (previously: PGI)"""
@@ -15,6 +13,7 @@ toolchain = SYSTEM
 sources = ['nvhpc_2020_%(version_major)s%(version_minor)s_Linux_x86_64_cuda_multi.tar.gz']
 checksums = ['a5c5c8726d2210f2310a852c6d6e03c9ef8c75e3643e9c94e24909f5e9c2ea7a']
 
+local_gccver = '9.3.0'
 dependencies = [
     ('GCCcore', local_gccver),
     ('binutils', '2.34', '', ('GCCcore', local_gccver)),
@@ -22,7 +21,12 @@ dependencies = [
     ('numactl', '2.0.13', '', ('GCCcore', local_gccver))
 ]
 
-default_cuda_version = None  # Use strings like "11.0" or use the command line: --try-amend=default_cuda_version="10.2"
+# specify default CUDA version that should be used by NVHPC
+# should match one of the CUDA versions that are included with this NVHPC version
+# (see install_components/Linux_x86_64/20.7/cuda/)
+# for NVHPC 20.7, those are: 11.0, 10.2, 10.1;
+# this version can be tweaked from the EasyBuild command line with --try-amend=default_cuda_version="10.2" (for example)
+default_cuda_version = '11.0'
 
 # NVHPC EasyBlock supports some features, which can be set via CLI or this easyconfig.
 # The following list gives examples for the easyconfig
@@ -33,17 +37,15 @@ default_cuda_version = None  # Use strings like "11.0" or use the command line: 
 #      default_cuda_version = "11.0"
 #    in this easyconfig file; alternatively, it can be specified through the command line during installation with
 #      --try-amend=default_cuda_version="10.2"
-# 2) System CUDA
-#    Use CUDA or CUDAcore as a dependency, for example
-#      dependencies = [('CUDA', '11.0.2', '', ('GCC', local_gccver))]
-#    or
+# 2) CUDA provided via EasyBuild
+#    Use CUDAcore as a dependency, for example
 #      dependencies = [('CUDAcore', '11.0.2')]
-#    The parameter default_cuda_version still can be set as above. If not set, it will be deduced from the
-#    CUDA module
+#    The parameter default_cuda_version still can be set as above.
+#    If not set, it will be deduced from the CUDA module (via $EBVERSIONCUDA)
 #
 # Define a NVHPC-default Compute Capability
 #   cuda_compute_capabilities = "8.0"
-# Can also be specified via --cuda-compute-capabilities=8.0
+# Can also be specified on the EasyBuild command line via --cuda-compute-capabilities=8.0
 # Only single values supported, not lists of values!
 #
 # Options to add/remove things to/from environment module (defaults shown)


### PR DESCRIPTION
@AndiH Tweaks for https://github.com/easybuilders/easybuild-easyconfigs/pull/11391/, as discussed during our call with @bartoldeman

This works for me as long as I use something like `eb --cuda-compute-capabilities 8.0` (since the easyblock enforces that some CUDA CC is specified either in the easyconfig or in the EasyBuild configuration).